### PR TITLE
collections is depricated

### DIFF
--- a/parsers/2012-yahoo_com.py
+++ b/parsers/2012-yahoo_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2013-imesh_com.py
+++ b/parsers/2013-imesh_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2015-000webhost_com.py
+++ b/parsers/2015-000webhost_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2015-patreon_com.py
+++ b/parsers/2015-patreon_com.py
@@ -54,7 +54,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         print('\nPlease wait. It takes a while to get to the data.', flush=True)
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:

--- a/parsers/2016-mate1_com.py
+++ b/parsers/2016-mate1_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2017-myheritage_com.py
+++ b/parsers/2017-myheritage_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2018-animoto_com.py
+++ b/parsers/2018-animoto_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2018-chegg_com.py
+++ b/parsers/2018-chegg_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2018-dubsmash_com.py
+++ b/parsers/2018-dubsmash_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2018-myfitnesspal_com.py
+++ b/parsers/2018-myfitnesspal_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2018-shein_com.py
+++ b/parsers/2018-shein_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2019-cafepress_com.py
+++ b/parsers/2019-cafepress_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2019-canva_com.py
+++ b/parsers/2019-canva_com.py
@@ -34,7 +34,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2019-hurb_com.py
+++ b/parsers/2019-hurb_com.py
@@ -37,7 +37,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2020-appen_com.py
+++ b/parsers/2020-appen_com.py
@@ -39,7 +39,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, salt
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2020-betfame_com.py
+++ b/parsers/2020-betfame_com.py
@@ -41,7 +41,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, passwd, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2020-bigbasket_com.py
+++ b/parsers/2020-bigbasket_com.py
@@ -39,7 +39,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2020-jefit_com.py
+++ b/parsers/2020-jefit_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2020-mobifriends_com.py
+++ b/parsers/2020-mobifriends_com.py
@@ -31,7 +31,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2020-mobifriends_com1.py
+++ b/parsers/2020-mobifriends_com1.py
@@ -33,7 +33,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2020-nulled_ch.py
+++ b/parsers/2020-nulled_ch.py
@@ -42,7 +42,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, salt
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as json_file:
             data = json.load(json_file)
             for row in data:

--- a/parsers/2020-pixlr_com.py
+++ b/parsers/2020-pixlr_com.py
@@ -42,7 +42,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2020-tamodo_com.py
+++ b/parsers/2020-tamodo_com.py
@@ -42,7 +42,7 @@ class Parse(base.Parser):
         domain = email.split('@')[1] if '@' in email else ''
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2020-teespring_com.py
+++ b/parsers/2020-teespring_com.py
@@ -34,7 +34,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2020-thingiverse_com.py
+++ b/parsers/2020-thingiverse_com.py
@@ -77,7 +77,7 @@ class Parse(base.Parser):
         
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2020-wattpad_com.py
+++ b/parsers/2020-wattpad_com.py
@@ -36,7 +36,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2020-wattpad_com1.py
+++ b/parsers/2020-wattpad_com1.py
@@ -35,7 +35,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-123rf_com.py
+++ b/parsers/2021-123rf_com.py
@@ -34,7 +34,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2021-dailyquiz_me.py
+++ b/parsers/2021-dailyquiz_me.py
@@ -36,7 +36,7 @@ class Parse(base.Parser):
         
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-descomplica_com_br.py
+++ b/parsers/2021-descomplica_com_br.py
@@ -38,7 +38,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-meetmindful_com.py
+++ b/parsers/2021-meetmindful_com.py
@@ -52,7 +52,7 @@ class Parse(base.Parser):
         domain = email.split('@')[1] if '@' in email else ''
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2021-nitropdf_com.py
+++ b/parsers/2021-nitropdf_com.py
@@ -61,7 +61,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2021-officegenie_co_uk.py
+++ b/parsers/2021-officegenie_co_uk.py
@@ -37,7 +37,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-parkmobile_us.py
+++ b/parsers/2021-parkmobile_us.py
@@ -38,7 +38,7 @@ class Parse(base.Parser):
         domain = email.split('@')[1] if '@' in email else ''
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-promofarma_com.py
+++ b/parsers/2021-promofarma_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-smdepot_net.py
+++ b/parsers/2021-smdepot_net.py
@@ -94,7 +94,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2021-thane_city.py
+++ b/parsers/2021-thane_city.py
@@ -34,7 +34,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-vipoferta_bg.py
+++ b/parsers/2021-vipoferta_bg.py
@@ -39,7 +39,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, salt
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-wedmegood_com.py
+++ b/parsers/2021-wedmegood_com.py
@@ -43,7 +43,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/2021-wish_com.py
+++ b/parsers/2021-wish_com.py
@@ -32,7 +32,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, password, '', ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Returns rows for the caller to process
         """

--- a/parsers/2021-wishbone_com.py
+++ b/parsers/2021-wishbone_com.py
@@ -66,7 +66,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/Plugin-Template.py
+++ b/parsers/Plugin-Template.py
@@ -39,7 +39,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, salt
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:

--- a/parsers/base.py
+++ b/parsers/base.py
@@ -116,7 +116,7 @@ class Parser(ABC):
             upload_blob(bucket_name, self.get_orc_name())
 
     @abstractmethod
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         """
             Yields processed & formatted rows from the dump returning a tuple
             with fields:

--- a/parsers/fake.py
+++ b/parsers/fake.py
@@ -27,7 +27,7 @@ class Parse(base.Parser):
 
         return self.name, self.web, int(self.year), domain, email, '', pw_hash, ''
 
-    def process_rows(self) -> collections.Iterable[tuple]:
+    def process_rows(self) -> collections.abc.Iterable[tuple]:
         with open(self.source, 'r', encoding='utf-8', errors='ignore') as source:
             for row in source:
                 if row is None:


### PR DESCRIPTION
when running parse on python 3.10 i got this error:
AttributeError: module 'collections' has no attribute 'Iterable'

'collections' is depricated and in 3.8 it stopped working, we need to use 'collections.abc'